### PR TITLE
add option to use full range (-1, 1) for joystick

### DIFF
--- a/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickDetailVH.java
+++ b/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickDetailVH.java
@@ -3,6 +3,7 @@ package com.schneewittchen.rosandroid.widgets.joystick;
 import android.text.Editable;
 import android.view.View;
 import android.widget.ArrayAdapter;
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
@@ -45,6 +46,8 @@ public class JoystickDetailVH extends PublisherWidgetViewHolder {
     private EditText yScaleRight;
     private TextView yScaleMiddle;
 
+    private CheckBox stickLimitBox;
+
     private ArrayAdapter<CharSequence> xDirAdapter;
     private ArrayAdapter<CharSequence> xAxisAdapter;
     private ArrayAdapter<CharSequence> yDirAdapter;
@@ -64,6 +67,8 @@ public class JoystickDetailVH extends PublisherWidgetViewHolder {
         yScaleLeft = view.findViewById(R.id.yScaleLeft);
         yScaleRight = view.findViewById(R.id.yScaleRight);
         yScaleMiddle = view.findViewById(R.id.yScaleMiddle);
+
+        stickLimitBox = view.findViewById(R.id.stickLimitBox);
 
         // Init spinner
         xDirAdapter = ArrayAdapter.createFromResource(view.getContext(),
@@ -100,6 +105,8 @@ public class JoystickDetailVH extends PublisherWidgetViewHolder {
         yScaleLeft.setText(String.format(Locale.US, "%.2f", widget.yScaleLeft));
         yScaleRight.setText(String.format(Locale.US, "%.2f", widget.yScaleRight));
         yScaleMiddle.setText(String.format(Locale.US, "%.2f", (widget.yScaleRight + widget.yScaleLeft) / 2));
+
+        stickLimitBox.setChecked(widget.realisticStickLimits);
     }
 
 
@@ -123,6 +130,7 @@ public class JoystickDetailVH extends PublisherWidgetViewHolder {
             } catch (Exception ignored) {
             }
         }
+        widget.realisticStickLimits = stickLimitBox.isChecked();
     }
 
     @Override

--- a/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickDetailVH.java
+++ b/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickDetailVH.java
@@ -1,6 +1,5 @@
 package com.schneewittchen.rosandroid.widgets.joystick;
 
-import android.text.Editable;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
@@ -8,12 +7,10 @@ import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
 
-import com.google.android.material.textfield.TextInputEditText;
 import com.schneewittchen.rosandroid.R;
 import com.schneewittchen.rosandroid.model.entities.widgets.BaseEntity;
 import com.schneewittchen.rosandroid.ui.views.details.PublisherWidgetViewHolder;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -106,7 +103,7 @@ public class JoystickDetailVH extends PublisherWidgetViewHolder {
         yScaleRight.setText(String.format(Locale.US, "%.2f", widget.yScaleRight));
         yScaleMiddle.setText(String.format(Locale.US, "%.2f", (widget.yScaleRight + widget.yScaleLeft) / 2));
 
-        stickLimitBox.setChecked(widget.realisticStickLimits);
+        stickLimitBox.setChecked(widget.rectangularStickLimits);
     }
 
 
@@ -130,7 +127,7 @@ public class JoystickDetailVH extends PublisherWidgetViewHolder {
             } catch (Exception ignored) {
             }
         }
-        widget.realisticStickLimits = stickLimitBox.isChecked();
+        widget.rectangularStickLimits = stickLimitBox.isChecked();
     }
 
     @Override

--- a/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickDetailVH.java
+++ b/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickDetailVH.java
@@ -50,6 +50,7 @@ public class JoystickDetailVH extends PublisherWidgetViewHolder {
     private ArrayAdapter<CharSequence> yDirAdapter;
     private ArrayAdapter<CharSequence> yAxisAdapter;
 
+    boolean forceSetChecked = false;
 
     @Override
     public void initView(View view) {
@@ -66,6 +67,9 @@ public class JoystickDetailVH extends PublisherWidgetViewHolder {
         yScaleMiddle = view.findViewById(R.id.yScaleMiddle);
 
         stickLimitBox = view.findViewById(R.id.stickLimitBox);
+        stickLimitBox.setOnCheckedChangeListener(((buttonView, isChecked) -> {
+            if (!forceSetChecked) forceWidgetUpdate();
+        }));
 
         // Init spinner
         xDirAdapter = ArrayAdapter.createFromResource(view.getContext(),
@@ -103,7 +107,9 @@ public class JoystickDetailVH extends PublisherWidgetViewHolder {
         yScaleRight.setText(String.format(Locale.US, "%.2f", widget.yScaleRight));
         yScaleMiddle.setText(String.format(Locale.US, "%.2f", (widget.yScaleRight + widget.yScaleLeft) / 2));
 
+        forceSetChecked = true;
         stickLimitBox.setChecked(widget.rectangularStickLimits);
+        forceSetChecked = false;
     }
 
 

--- a/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickEntity.java
+++ b/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickEntity.java
@@ -23,7 +23,7 @@ public class JoystickEntity extends PublisherWidgetEntity {
     public float xScaleRight;
     public float yScaleLeft;
     public float yScaleRight;
-
+    public boolean realisticStickLimits;
 
     public JoystickEntity() {
         this.width = 4;
@@ -37,6 +37,7 @@ public class JoystickEntity extends PublisherWidgetEntity {
         this.xScaleRight = -1;
         this.yScaleLeft = -1;
         this.yScaleRight = 1;
+        this.realisticStickLimits = true;
     }
 
 }

--- a/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickEntity.java
+++ b/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickEntity.java
@@ -23,7 +23,7 @@ public class JoystickEntity extends PublisherWidgetEntity {
     public float xScaleRight;
     public float yScaleLeft;
     public float yScaleRight;
-    public boolean realisticStickLimits;
+    public boolean rectangularStickLimits;
 
     public JoystickEntity() {
         this.width = 4;
@@ -37,7 +37,7 @@ public class JoystickEntity extends PublisherWidgetEntity {
         this.xScaleRight = -1;
         this.yScaleLeft = -1;
         this.yScaleRight = 1;
-        this.realisticStickLimits = true;
+        this.rectangularStickLimits = false;
     }
 
 }

--- a/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickView.java
+++ b/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickView.java
@@ -101,9 +101,13 @@ public class JoystickView extends PublisherWidgetView {
 
         float[] px = convertFromPolarToPx(posX, posY);
 
-        // Outer ring
-        canvas.drawCircle(width/2, height/2, width/2-joystickRadius, outerPaint);
-
+        JoystickEntity entity = (JoystickEntity) widgetEntity;
+        if(entity.realisticStickLimits){
+            // Outer ring
+            canvas.drawCircle(width / 2, height / 2, width / 2 - joystickRadius, outerPaint);
+        }else {
+            canvas.drawRect(0, 0, width, height, outerPaint);
+        }
         // Inner drawings
         canvas.drawCircle(width/2, height/2, width/4-joystickRadius/2, linePaint);
         canvas.drawLine(joystickRadius, height/2, width-joystickRadius, height/2,  linePaint);
@@ -125,12 +129,21 @@ public class JoystickView extends PublisherWidgetView {
         double rad = Math.atan2(dy, dx);
 
         double len = Math.sqrt(dx*dx + dy*dy)/r;
-        len = Math.min(1, len);
+        JoystickEntity entity = (JoystickEntity) widgetEntity;
+        if (entity.realisticStickLimits) {
+            len = Math.min(1, len);
+        }
 
         float[] polar = new float[2];
 
         polar[0] = (float) (Math.cos(rad)*len);
         polar[1] = (float) (-Math.sin(rad)*len);
+
+        if(!entity.realisticStickLimits){
+            // clip polar between -1 and 1
+            polar[0] = Math.max(-1, Math.min(polar[0], 1));
+            polar[1] = Math.max(-1, Math.min(polar[1], 1));
+        }
 
         return polar;
     }

--- a/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickView.java
+++ b/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickView.java
@@ -106,7 +106,7 @@ public class JoystickView extends PublisherWidgetView {
             // Outer ring
             canvas.drawCircle(width / 2, height / 2, width / 2 - joystickRadius, outerPaint);
         }else {
-            canvas.drawRect(0, 0, width, height, outerPaint);
+            canvas.drawRect(joystickRadius, joystickRadius, width-joystickRadius, height-joystickRadius, outerPaint);
         }
         // Inner drawings
         canvas.drawCircle(width/2, height/2, width/4-joystickRadius/2, linePaint);

--- a/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickView.java
+++ b/app/src/main/java/com/schneewittchen/rosandroid/widgets/joystick/JoystickView.java
@@ -102,14 +102,17 @@ public class JoystickView extends PublisherWidgetView {
         float[] px = convertFromPolarToPx(posX, posY);
 
         JoystickEntity entity = (JoystickEntity) widgetEntity;
-        if(entity.realisticStickLimits){
-            // Outer ring
-            canvas.drawCircle(width / 2, height / 2, width / 2 - joystickRadius, outerPaint);
-        }else {
+        if(entity.rectangularStickLimits){
+            // Outer box
             canvas.drawRect(joystickRadius, joystickRadius, width-joystickRadius, height-joystickRadius, outerPaint);
+            // Inner box
+            canvas.drawRect(width/4 + joystickRadius/2, height/4+joystickRadius/2, width*(3f/4)-joystickRadius/2, height*(3f/4)-joystickRadius/2, linePaint);
+        }else {
+            // Outer ring
+            canvas.drawCircle(width/2, height/2, width/2- joystickRadius, outerPaint);
+            // Inner drawings
+            canvas.drawCircle(width/2, height/2, width/4 - joystickRadius/2, linePaint);
         }
-        // Inner drawings
-        canvas.drawCircle(width/2, height/2, width/4-joystickRadius/2, linePaint);
         canvas.drawLine(joystickRadius, height/2, width-joystickRadius, height/2,  linePaint);
         canvas.drawLine(width/2, height/2 - width/2 + joystickRadius ,
                         width/2, height/2 + width/2 - joystickRadius,  linePaint);
@@ -130,7 +133,7 @@ public class JoystickView extends PublisherWidgetView {
 
         double len = Math.sqrt(dx*dx + dy*dy)/r;
         JoystickEntity entity = (JoystickEntity) widgetEntity;
-        if (entity.realisticStickLimits) {
+        if (!entity.rectangularStickLimits) {
             len = Math.min(1, len);
         }
 
@@ -139,7 +142,7 @@ public class JoystickView extends PublisherWidgetView {
         polar[0] = (float) (Math.cos(rad)*len);
         polar[1] = (float) (-Math.sin(rad)*len);
 
-        if(!entity.realisticStickLimits){
+        if(entity.rectangularStickLimits){
             // clip polar between -1 and 1
             polar[0] = Math.max(-1, Math.min(polar[0], 1));
             polar[1] = Math.max(-1, Math.min(polar[1], 1));

--- a/app/src/main/res/layout/widget_detail_joystick.xml
+++ b/app/src/main/res/layout/widget_detail_joystick.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:android="http://schemas.android.com/apk/res/android"
@@ -212,6 +212,18 @@
         app:layout_constraintEnd_toEndOf="@+id/xAxisScale2"
         app:layout_constraintStart_toEndOf="@+id/xAxisScale2"
         app:layout_constraintTop_toBottomOf="@+id/xAxisScale2" />
+
+    <CheckBox
+        android:id="@+id/stickLimitBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="76dp"
+        android:text="Realistic Stick Limits"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small"
+        android:textColor="@color/colorAccent"
+        android:textStyle="bold"
+        app:layout_constraintTop_toBottomOf="@+id/xAxisScale2"
+        tools:layout_editor_absoluteX="0dp" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/widget_detail_joystick.xml
+++ b/app/src/main/res/layout/widget_detail_joystick.xml
@@ -218,7 +218,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="76dp"
-        android:text="Realistic Stick Limits"
+        android:text="Use Rectangular Stick Limits"
         android:textAppearance="@style/TextAppearance.AppCompat.Small"
         android:textColor="@color/colorAccent"
         android:textStyle="bold"


### PR DESCRIPTION
Adds a checkbox, "Use Realistic Stick Limits", to the joystick widget. It's checked by default, keeping the default behavior the same, where the joystick areas is a circle, and the corners can't be reached. When unchecked, the boundaries of the virtual joystick change to a square (or rectangle, if the width/height are not equal), making the corners reachable.

The new checkbox:
<img src="https://user-images.githubusercontent.com/2405137/160167830-c1f820b6-d7ba-4e0f-895f-08b9bdbb403a.png" width="30%" />

Joystick in square/rect mode:
<img src="https://user-images.githubusercontent.com/2405137/160167863-56e3dd1b-8b3c-45fe-a00a-c0e23be0d0d3.png" width="30%" />


Joystick in realistic mode:
<img src="https://user-images.githubusercontent.com/2405137/160167896-ac4432e8-e1bc-4862-b067-6bfad2e0fba0.png" width="30%" />